### PR TITLE
bringing back losing the _connection

### DIFF
--- a/snowconn/connect.py
+++ b/snowconn/connect.py
@@ -272,7 +272,14 @@ class SnowConn:
         # which is robust but has the unfortunate side effect of causing the
         # process to hang for a bit before it is closed. that means that all
         # users of snowflake_conn have a few second delay when the script exits
-        # self._connection.close()
+        
+        # Update: I've been experimenting with my own version of this with the
+        # following line uncommented and have not noticed any issues. I'm
+        # thinking that the issue described above isn't a problem any more.
+        # Furthermote, bringing back this line of code stops the connection
+        # from hanging in some cases where an exception is thrown during
+        # or right after a query.
+        self._connection.close()
         self._alchemy_engine.dispose()
 
     def get_current_role(self):


### PR DESCRIPTION
Been testing on my own for a while and the originally described issue does not seem to be there. Plus, it fixes a few times where the process hangs when an exception is thrown before you have a chance to close it.