### PR TITLE
Bump version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
     docker:
       # specify the version you desire here
       # use `-browsers` prefix for selenium tests, e.g. `3.6.1-browsers`
-      - image: circleci/python:3.6.1
+      - image: circleci/python:3.7.1
 
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images


### PR DESCRIPTION
Merges https://github.com/Daltix/snowconn/pull/17 , https://github.com/Daltix/snowconn/pull/15

Notes:
  - SnowConn.connect now allows a `methods` argument to specify a list of authentication methods to try.
  - Adds deprecation warning for method `credsman_connect`
  - Support for local config SSO authentication
  - Context manager ensures the connection is properly destroyed when there are exceptions. (An outstanding [snowflake-python-connector issue](https://community.snowflake.com/s/article/Python-connector-does-not-implement-a-destructor-method-correctly))
