### PR TITLE
Added usage of Snowflake's 'pd_writer'.

### DIFF
--- a/snowconn/connect.py
+++ b/snowconn/connect.py
@@ -7,6 +7,7 @@ import warnings
 import configparser
 import snowflake.connector
 from sqlalchemy import create_engine
+from snowflake.connector.pandas_tools import pd_writer
 
 
 class InvalidMethodException(Exception):
@@ -333,7 +334,8 @@ class SnowConn:
 
         if not temporary_table:
             df.to_sql(table, con=self._connection,
-                      if_exists=if_exists, index=index, chunksize=chunksize,
+                      if_exists=if_exists, index=index,
+                      chunksize=chunksize, method=pd_writer,
                       **kwargs)
         else:
             import pandas as pd


### PR DESCRIPTION
Instead of using `write_pandas`, I opted for using `pd_writer` which is a much smaller change. It is one of the [two methods described in the documentation](https://docs.snowflake.com/en/user-guide/python-connector-pandas.html#writing-data-from-a-pandas-dataframe-to-a-snowflake-database) (the other one being `write_pandas`).

I quickly tested it locally by doing:
```
>>> from snowconn import SnowConn
>>> conn = SnowConn.connect()
>>> import pandas as pd
>>> df = util.testing.makeDataFrame() # taken from https://www.pauldesalvo.com/creating-a-random-or-test-dataframe-in-pandas/
# insert statements to use the test DB and schema of your choice
>>> conn.write_df(df, 'potato')
>>> read_df('select * from potato')
```

The reason why I have it in draft is because of the installation instructions for the requirements. They [are more convoluted](https://docs.snowflake.com/en/user-guide/python-connector-install.html#step-1-install-the-connector) than just a `pip install` command. We can pin a version of snowflake-python-connector and copy-paste the requirements of that version, maybe?