### PR TITLE
Bump snowflake-connector-python and snowflake-sqlalchemy versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,9 +18,8 @@ setup(
     author_email='snowconn@daltix.com',
     packages=['snowconn'],
     install_requires=[
-        'wheel',
         'six',
-        'snowflake-connector-python>=2.7.9,<2.8.0',
+        'snowflake-connector-python==2.7.9',
         'snowflake-sqlalchemy>=1.3, <1.4',
     ],
     long_description=long_description,
@@ -28,15 +27,15 @@ setup(
 
     extras_require={
         "pandas": [
-            "snowflake-connector-python[pandas]>=2.7.9,<2.8.0",
+            "snowflake-connector-python[pandas]==2.7.9",
         ],
         "storage": [
-            "snowflake-connector-python[secure-local-storage]>=2.7.9,<2.8.0",
+            "snowflake-connector-python[secure-local-storage]==2.7.9",
             'wheel',
         ],
         "all": [
             "boto3",
-            "snowflake-connector-python[secure-local-storage,pandas]>=2.7.9,<2.8.0",
+            "snowflake-connector-python[secure-local-storage,pandas]==2.7.9",
         ]
     }
 )

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(readme_path, encoding='utf-8') as fh:
 
 setup(
     name='snowconn',
-    version='3.8.3',
+    version='3.9.0',
     description='Python utilities for connection to the Snowflake data '
                 'warehouse',
     url='https://github.com/Daltix/snowconn',
@@ -18,24 +18,25 @@ setup(
     author_email='snowconn@daltix.com',
     packages=['snowconn'],
     install_requires=[
-        'wheel==0.32.3',
-        'snowflake-connector-python==2.4.2',
-        'snowflake-sqlalchemy>=1.2, <1.3',
+        'wheel',
+        'six',
+        'snowflake-connector-python>=2.7.9,<2.8.0',
+        'snowflake-sqlalchemy>=1.3, <1.4',
     ],
     long_description=long_description,
     long_description_content_type='text/markdown',
 
     extras_require={
         "pandas": [
-            "snowflake-connector-python[pandas]==2.4.2",
+            "snowflake-connector-python[pandas]>=2.7.9,<2.8.0",
         ],
         "storage": [
-            "snowflake-connector-python[secure-local-storage]==2.4.2",
+            "snowflake-connector-python[secure-local-storage]>=2.7.9,<2.8.0",
             'wheel',
         ],
         "all": [
             "boto3",
-            "snowflake-connector-python[secure-local-storage,pandas]==2.4.2",
+            "snowflake-connector-python[secure-local-storage,pandas]>=2.7.9,<2.8.0",
         ]
     }
 )


### PR DESCRIPTION
This versions will already support the latestest versions of numpy (>=1.19), which is compatible with M1 arm64 architecture

Resolve DA-2041