### PR TITLE
bump snowconn dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(readme_path, encoding='utf-8') as fh:
 
 setup(
     name='snowconn',
-    version='3.8.3',
+    version='3.11',
     description='Python utilities for connection to the Snowflake data '
                 'warehouse',
     url='https://github.com/Daltix/snowconn',
@@ -18,24 +18,24 @@ setup(
     author_email='snowconn@daltix.com',
     packages=['snowconn'],
     install_requires=[
-        'wheel==0.32.3',
-        'snowflake-connector-python==2.4.2',
-        'snowflake-sqlalchemy>=1.2, <1.3',
+        'wheel==0.40.0',
+        'snowflake-connector-python==3.0.4',
+        'snowflake-sqlalchemy==1.4.7',
     ],
     long_description=long_description,
     long_description_content_type='text/markdown',
 
     extras_require={
         "pandas": [
-            "snowflake-connector-python[pandas]==2.4.2",
+            "snowflake-connector-python[pandas]==3.0.4",
         ],
         "storage": [
-            "snowflake-connector-python[secure-local-storage]==2.4.2",
+            "snowflake-connector-python[secure-local-storage]==3.0.4",
             'wheel',
         ],
         "all": [
             "boto3",
-            "snowflake-connector-python[secure-local-storage,pandas]==2.4.2",
+            "snowflake-connector-python[secure-local-storage,pandas]==3.0.4",
         ]
     }
 )


### PR DESCRIPTION
# What

Update dependencies of Snowconn:  
- snowflake-python-connector to version 3.0.4
- snowflake-sqlalchemy to version 1.4.7
- wheel to 0.40.0